### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/common/rsa.go
+++ b/common/rsa.go
@@ -8,7 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 /*
@@ -82,10 +82,10 @@ func (encry RSAEncryption) Decode(encode []byte, publicKey string) ([]byte, erro
 	if err != nil {
 		return []byte(""), err
 	}
-	return ioutil.ReadAll(output)
+	return io.ReadAll(output)
 }
 
-//ckman do not need encode token
+// ckman do not need encode token
 func (encry RSAEncryption) Encode(decode []byte, privateKey string) ([]byte, error) {
 	prikey, _ := encry.GetPrivateKey(privateKey)
 	if prikey == nil {
@@ -96,7 +96,7 @@ func (encry RSAEncryption) Encode(decode []byte, privateKey string) ([]byte, err
 	if err != nil {
 		return []byte(""), err
 	}
-	rsadata, err := ioutil.ReadAll(output)
+	rsadata, err := io.ReadAll(output)
 	if err != nil {
 		return []byte(""), err
 	}

--- a/common/ssh.go
+++ b/common/ssh.go
@@ -3,15 +3,15 @@ package common
 import (
 	"bufio"
 	"fmt"
-	"github.com/housepower/ckman/config"
-	"github.com/housepower/ckman/log"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/housepower/ckman/config"
+	"github.com/housepower/ckman/log"
 
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
@@ -34,7 +34,7 @@ func sshConnectwithPassword(user, password string) (*ssh.ClientConfig, error) {
 }
 
 func sshConnectwithPublickKey(user string) (*ssh.ClientConfig, error) {
-	key, err := ioutil.ReadFile(path.Join(config.GetWorkDirectory(), "conf", "id_rsa"))
+	key, err := os.ReadFile(path.Join(config.GetWorkDirectory(), "conf", "id_rsa"))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func SSHRun(client *ssh.Client, password, shell string) (result string, err erro
 				continue
 			}
 			line += string(b)
-			//TODO I have no idea to slove this problem: "xxx is not in the sudoers file.  This incident will be reported."
+			// TODO I have no idea to slove this problem: "xxx is not in the sudoers file.  This incident will be reported."
 			if strings.HasPrefix(line, "[sudo] password for ") && strings.HasSuffix(line, ": ") {
 				_, err = in.Write([]byte(password + "\n"))
 				if err != nil {
@@ -256,7 +256,7 @@ func ScpUploadFiles(files []string, remotePath, user, password, ip string, port 
 			continue
 		}
 		remoteFile := path.Join(remotePath, path.Base(file))
-		err = ScpUploadFile(file, remoteFile, user, password, ip, port )
+		err = ScpUploadFile(file, remoteFile, user, password, ip, port)
 		if err != nil {
 			return err
 		}
@@ -270,7 +270,7 @@ func ScpUploadFile(localFile, remoteFile, user, password, ip string, port int) e
 		return err
 	}
 	defer sftpClient.Close()
-	//delete remote file first, beacuse maybe the remote file exists and created by root
+	// delete remote file first, beacuse maybe the remote file exists and created by root
 	cmd := fmt.Sprintf("rm -rf %s", path.Join(TmpWorkDirectory, path.Base(remoteFile)))
 	_, err = RemoteExecute(user, password, ip, port, cmd)
 	if err != nil {
@@ -367,4 +367,3 @@ func genFinalScript(user, cmd string) string {
 	}
 	return shell
 }
-

--- a/common/util.go
+++ b/common/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -150,7 +149,7 @@ type TempFile struct {
 }
 
 func NewTempFile(dir, prefix string) (TempFile, error) {
-	f, err := ioutil.TempFile(dir, prefix)
+	f, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		return TempFile{}, err
 	}
@@ -170,20 +169,19 @@ func DeepCopyByGob(dst, src interface{}) error {
 	return gob.NewDecoder(bytes.NewBuffer(buf.Bytes())).Decode(dst)
 }
 
-
 func ArraySearch(target string, str_array []string) bool {
 	for _, str := range str_array {
 		if target == str {
 			return true
 		}
- 	}
+	}
 	return false
 }
 
 func ReplaceTemplateString(src *string, replace map[string]interface{}) error {
 	t, err := template.New("T1").Parse(*src)
 	if err != nil {
-		return  err
+		return err
 	}
 	buf := new(bytes.Buffer)
 	err = t.Execute(buf, replace)

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,8 +35,8 @@ type CKManServerConfig struct {
 	Ip             string
 	Port           int
 	Https          bool
-	CertFile       string	`yaml:"certfile"`
-	KeyFile        string	`yaml:"keyfile"`
+	CertFile       string `yaml:"certfile"`
+	KeyFile        string `yaml:"keyfile"`
 	Pprof          bool
 	SessionTimeout int    `yaml:"session_timeout"`
 	SwaggerEnable  bool   `yaml:"swagger_enable"`
@@ -95,7 +95,7 @@ func ParseConfigFile(path, version string) error {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/controller/deploy.go
+++ b/controller/deploy.go
@@ -2,6 +2,10 @@ package controller
 
 import (
 	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-errors/errors"
 	"github.com/housepower/ckman/business"
@@ -12,9 +16,6 @@ import (
 	"github.com/housepower/ckman/model"
 	"github.com/housepower/ckman/service/clickhouse"
 	"github.com/housepower/ckman/service/nacos"
-	"io/ioutil"
-	"strconv"
-	"strings"
 )
 
 type DeployController struct {
@@ -112,7 +113,7 @@ func (d *DeployController) DeployCk(c *gin.Context) {
 		model.WrapMsg(c, model.GET_SCHEMA_UI_FAILED, errors.Errorf("type %s is not registered", GET_SCHEMA_UI_DEPLOY))
 		return
 	}
-	body, err := ioutil.ReadAll(c.Request.Body)
+	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		model.WrapMsg(c, model.INVALID_PARAMS, err)
 		return
@@ -307,11 +308,11 @@ func checkAccess(localPath string, conf *model.CKManClickHouseConfig) error {
 
 func SyncLogicSchema(src, dst model.CKManClickHouseConfig) bool {
 	hosts, err := common.GetShardAvaliableHosts(&src)
-	if err != nil || len(hosts) == 0{
+	if err != nil || len(hosts) == 0 {
 		log.Logger.Warnf("cluster %s all node is unvaliable", src.Cluster)
 		return false
 	}
-	srcDB, err := common.ConnectClickHouse(hosts[0], src.Port, model.ClickHouseDefaultDB,src.User, src.Password)
+	srcDB, err := common.ConnectClickHouse(hosts[0], src.Port, model.ClickHouseDefaultDB, src.User, src.Password)
 	if err != nil {
 		log.Logger.Warnf("connect %s failed", hosts[0])
 		return false

--- a/controller/package.go
+++ b/controller/package.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -173,7 +172,7 @@ func (p *PackageController) List(c *gin.Context) {
 func GetAllFiles(dirPth string) ([]string, error) {
 	files := make([]string, 0)
 
-	dir, err := ioutil.ReadDir(dirPth)
+	dir, err := os.ReadDir(dirPth)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/user.go
+++ b/controller/user.go
@@ -1,17 +1,17 @@
 package controller
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
-	"github.com/patrickmn/go-cache"
 	"github.com/housepower/ckman/common"
 	"github.com/housepower/ckman/config"
 	"github.com/housepower/ckman/model"
+	"github.com/patrickmn/go-cache"
 )
 
 var TokenCache *cache.Cache
@@ -50,7 +50,7 @@ func (d *UserController) Login(c *gin.Context) {
 	}
 
 	passwordFile := path.Join(filepath.Dir(d.config.ConfigFile), "password")
-	data, err := ioutil.ReadFile(passwordFile)
+	data, err := os.ReadFile(passwordFile)
 	if err != nil {
 		model.WrapMsg(c, model.GET_USER_PASSWORD_FAIL, err)
 		return
@@ -65,7 +65,7 @@ func (d *UserController) Login(c *gin.Context) {
 	claims := common.CustomClaims{
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt: time.Now().Unix(),
-			//ExpiresAt: time.Now().Add(time.Second * time.Duration(d.config.Server.SessionTimeout)).Unix(),
+			// ExpiresAt: time.Now().Add(time.Second * time.Duration(d.config.Server.SessionTimeout)).Unix(),
 		},
 		Name:     common.DefaultUserName,
 		ClientIP: c.ClientIP(),
@@ -80,7 +80,7 @@ func (d *UserController) Login(c *gin.Context) {
 		Username: req.Username,
 		Token:    token,
 	}
-	TokenCache.SetDefault(token, time.Now().Add(time.Second * time.Duration(d.config.Server.SessionTimeout)).Unix())
+	TokenCache.SetDefault(token, time.Now().Add(time.Second*time.Duration(d.config.Server.SessionTimeout)).Unix())
 
 	model.WrapMsg(c, model.SUCCESS, rsp)
 }

--- a/controller/zookeeper.go
+++ b/controller/zookeeper.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -75,7 +75,7 @@ func getZkStatus(host string, port int) ([]byte, error) {
 		return nil, errors.Errorf("%s", response.Status)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/model/request.go
+++ b/model/request.go
@@ -1,15 +1,16 @@
 package model
 
 import (
-	jsoniter "github.com/json-iterator/go"
-	"io/ioutil"
+	"io"
 	"net/http"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func DecodeRequestBody(request *http.Request, v interface{}) error {
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		return err
 	}

--- a/service/clickhouse/clickhouse_service.go
+++ b/service/clickhouse/clickhouse_service.go
@@ -3,14 +3,6 @@ package clickhouse
 import (
 	"database/sql"
 	"fmt"
-	"github.com/housepower/ckman/business"
-	"github.com/housepower/ckman/common"
-	"github.com/housepower/ckman/config"
-	"github.com/housepower/ckman/log"
-	"github.com/housepower/ckman/model"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -19,6 +11,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/housepower/ckman/business"
+	"github.com/housepower/ckman/common"
+	"github.com/housepower/ckman/config"
+	"github.com/housepower/ckman/log"
+	"github.com/housepower/ckman/model"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -86,7 +86,7 @@ func ReadClusterConfigFile() ([]byte, error) {
 		return nil, nil
 	}
 
-	data, err := ioutil.ReadFile(localFile)
+	data, err := os.ReadFile(localFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "")
 	}
@@ -509,7 +509,7 @@ func (ck *CkService) DeleteTable(conf *model.CKManClickHouseConfig, params *mode
 		return err
 	}
 
-	//delete zoopath
+	// delete zoopath
 	tableName := fmt.Sprintf("%s.%s", params.DB, params.Name)
 	delete(conf.ZooPath, tableName)
 
@@ -575,7 +575,6 @@ func (ck *CkService) AlterTable(params *model.AlterCkTableParams) error {
 		}
 	}
 
-
 	// 删除分布式表并重建
 	delete := fmt.Sprintf("DROP TABLE %s.%s%s ON CLUSTER %s",
 		params.DB, ClickHouseDistributedTablePrefix, params.Name, params.Cluster)
@@ -592,8 +591,8 @@ func (ck *CkService) AlterTable(params *model.AlterCkTableParams) error {
 		return err
 	}
 
-	//删除逻辑表并重建（如果有的话）
-	conf,_ := CkClusters.GetClusterByName(params.Cluster)
+	// 删除逻辑表并重建（如果有的话）
+	conf, _ := CkClusters.GetClusterByName(params.Cluster)
 
 	if conf.LogicCluster != nil {
 		distParams := model.DistLogicTblParams{
@@ -937,7 +936,7 @@ func GetReplicaZkPath(conf *model.CKManClickHouseConfig) error {
 		return err
 	}
 
-	//clear and reload again
+	// clear and reload again
 	conf.ZooPath = make(map[string]string)
 	for _, database := range databases {
 		if tables, ok := dbtables[database]; ok {
@@ -1046,7 +1045,7 @@ func DropTableIfExists(params model.CreateCkTableParams, ck *CkService) {
 	_, _ = ck.DB.Exec(dropSql)
 }
 
-func (ck *CkService)ShowCreateTable(tbname, database string) (string, error) {
+func (ck *CkService) ShowCreateTable(tbname, database string) (string, error) {
 	query := fmt.Sprintf("SELECT create_table_query FROM system.tables WHERE database = '%s' AND name = '%s'", database, tbname)
 	value, err := ck.QueryInfo(query)
 	if err != nil {
@@ -1056,7 +1055,7 @@ func (ck *CkService)ShowCreateTable(tbname, database string) (string, error) {
 	return schema, nil
 }
 
-func GetCKVersion(conf *model.CKManClickHouseConfig, host string)(string, error) {
+func GetCKVersion(conf *model.CKManClickHouseConfig, host string) (string, error) {
 	tmp := *conf
 	tmp.Hosts = []string{host}
 	service, err := GetCkService(conf.Cluster)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since ckman has been upgraded to Go 1.17 (001704e17071b809bb93a542fa4508469c3cf241), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.