### PR TITLE
Update ck_rebalance.go

### DIFF
--- a/business/ck_rebalance.go
+++ b/business/ck_rebalance.go
@@ -223,6 +223,7 @@ func (this *CKRebalance) ExecutePlan(database string, tbl *TblPartitions) (err e
 				return fmt.Errorf("can't get connection: %s", dstHost)
 			}
 			dstQuires := []string{
+				fmt.Sprintf("ALTER TABLE %s DROP DETACHED PARTITION '%s' ", tbl.Table, patt),
 				fmt.Sprintf("ALTER TABLE %s FETCH PARTITION '%s' FROM '%s'", tbl.Table, patt, tbl.ZooPath),
 				fmt.Sprintf("ALTER TABLE %s ATTACH PARTITION '%s'", tbl.Table, patt),
 			}


### PR DESCRIPTION
执行rebalance时报错：
![image](https://user-images.githubusercontent.com/38677757/146345609-6d1be3f6-b1a5-4b2a-81ae-49fcb2478f11.png)
查看前文打印的日志：
![image](https://user-images.githubusercontent.com/38677757/146346827-70410629-cd9a-4a17-9496-420287b7a514.png)
![image](https://user-images.githubusercontent.com/38677757/146346321-b38f8d22-a79e-46f7-8129-2c027cff0619.png)
可以看出是在217执行ALTER TABLE default.t_unstr_log_local FETCH PARTITION '20211201' FROM '/clickhouse/tables/cluster_2replica/default/t_unstr_log_local/1'这条SQL时报错。
现在去217执行这条SQL，复现报错：
![image](https://user-images.githubusercontent.com/38677757/146347275-db787efe-7f87-417b-989c-7e44e1a93f0c.png)
如果我们这时候先执行ALTER TABLE t_unstr_log_local DROP DETACHED PARTITION '20211201';
再去跑ALTER TABLE default.t_unstr_log_local FETCH PARTITION '20211201' FROM '/clickhouse/tables/cluster_2replica/default/t_unstr_log_local/1'，结果没有报错：
![image](https://user-images.githubusercontent.com/38677757/146351882-096cd89a-a4ff-485f-a65e-887c6df2f816.png)


