### PR TITLE
DSN中增大read_timeout

### DIFF
--- a/business/ck_rebalance.go
+++ b/business/ck_rebalance.go
@@ -223,6 +223,7 @@ func (this *CKRebalance) ExecutePlan(database string, tbl *TblPartitions) (err e
 				return fmt.Errorf("can't get connection: %s", dstHost)
 			}
 			dstQuires := []string{
+				fmt.Sprintf("ALTER TABLE %s DROP DETACHED PARTITION '%s' ", tbl.Table, patt),
 				fmt.Sprintf("ALTER TABLE %s FETCH PARTITION '%s' FROM '%s'", tbl.Table, patt, tbl.ZooPath),
 				fmt.Sprintf("ALTER TABLE %s ATTACH PARTITION '%s'", tbl.Table, patt),
 			}

--- a/common/ck.go
+++ b/common/ck.go
@@ -24,7 +24,7 @@ func ConnectClickHouse(host string, port int, database string, user string, pass
 	var db *sql.DB
 	var err error
 
-	dsn := fmt.Sprintf("tcp://%s:%d?database=%s&username=%s&password=%s",
+	dsn := fmt.Sprintf("tcp://%s:%d?database=%s&username=%s&password=%s&read_timeout=300",
 		host, port, url.QueryEscape(database), url.QueryEscape(user), url.QueryEscape(password))
 	log.Logger.Debugf("dsn: %s", dsn)
 


### PR DESCRIPTION
目前使用clickhosue-go连接clickhosue的dsn中没有指定read_timeout，默认为1分钟，所以导致在执行ALTER TABLE default.t_unstr_log_local FETCH PARTITION '20211202' FROM '/clickhouse/tables/cluster_2replica/default/t_unstr_log_local/1';这种运行时间过长的SQL时会在1分钟后断开连接，然而在sql.go中设置了maxBadConnRetries为2
![image](https://user-images.githubusercontent.com/38677757/146883002-1762bc10-4e54-41db-bd4b-dc4765e2f961.png)
即如果是连接断开的报错，总共有3次机会重试SQL。所以导致每隔一分钟会重复执行ALTER TABLE default.t_unstr_log_local FETCH PARTITION ，直至遇到报错。
![image](https://user-images.githubusercontent.com/38677757/146884878-e30d0518-a6e1-44e6-8faa-f9d87fb54d92.png)
![image](https://user-images.githubusercontent.com/38677757/146883698-7f01e85c-e988-4eb8-9013-c561204e7a32.png)

增大read_timeout到300（5分钟）后，就没有再遇到报错。
![image](https://user-images.githubusercontent.com/38677757/146884046-9a29f7e2-df24-4200-a47a-bcb352774320.png)
