### PR TITLE
fix Decimal128 is not supported bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/housepower/ckman
 go 1.17
 
 require (
-	github.com/ClickHouse/clickhouse-go v1.4.5
+	github.com/ClickHouse/clickhouse-go v1.4.6
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/choidamdam/gin-static-pkger v0.0.0-20201119021339-c0f138638274
 	github.com/colinmarc/hdfs/v2 v2.2.0
@@ -40,6 +40,7 @@ require (
 require (
 	github.com/go-basic/uuid v1.0.0
 	github.com/imdario/mergo v0.3.12
+	github.com/shopspring/decimal v1.3.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gorm.io/driver/mysql v1.1.2
 	gorm.io/gorm v1.21.16

--- a/go.sum
+++ b/go.sum
@@ -513,6 +513,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/service/clickhouse/clickhouse_service.go
+++ b/service/clickhouse/clickhouse_service.go
@@ -3,7 +3,10 @@ package clickhouse
 import (
 	"database/sql"
 	"fmt"
+	_ "github.com/ClickHouse/clickhouse-go/lib/column"
 	"github.com/housepower/ckman/repository"
+	"github.com/shopspring/decimal"
+	"math/big"
 	"net"
 	"sort"
 	"strings"
@@ -479,6 +482,11 @@ func (ck *CkService) QueryInfo(query string) ([][]interface{}, error) {
 		return nil, err
 	}
 
+	colTypes, errType := rows.ColumnTypes()
+	if errType != nil {
+		return nil, errType
+	}
+
 	colData := make([][]interface{}, 0)
 	colNames := make([]interface{}, len(cols))
 	// Create a slice of interface{}'s to represent each column,
@@ -501,8 +509,16 @@ func (ck *CkService) QueryInfo(query string) ([][]interface{}, error) {
 		// storing it in the map with the name of the column as the key.
 		m := make([]interface{}, len(cols))
 		for i := range columnPointers {
+			colType :=colTypes[i]
 			val := columnPointers[i].(*interface{})
-			m[i] = *val
+			if strings.HasPrefix(colType.DatabaseTypeName(), "Decimal("){
+				_, scale,_ :=colType.DecimalSize()
+				value :=*val
+				byteValue := value.([]uint8)
+				m[i] =decimal.NewFromBigInt(rawToBigInt(byteValue),int32(-scale))
+			}else {
+				m[i] = *val
+			}
 		}
 
 		colData = append(colData, m)
@@ -512,6 +528,32 @@ func (ck *CkService) QueryInfo(query string) ([][]interface{}, error) {
 	}
 
 	return colData, nil
+}
+func rawToBigInt(v []byte) *big.Int {
+	// LittleEndian to BigEndian
+	endianSwap(v, false)
+	var lt = new(big.Int)
+	if len(v) > 0 && v[0]&0x80 != 0 {
+		// [0] ^ will +1
+		for i := 0; i < len(v); i++ {
+			v[i] = ^v[i]
+		}
+		lt.SetBytes(v)
+		// neg ^ will -1
+		lt.Not(lt)
+	} else {
+		lt.SetBytes(v)
+	}
+	return lt
+}
+func endianSwap(src []byte, not bool) {
+	for i := 0; i < len(src)/2; i++ {
+		if not {
+			src[i], src[len(src)-i-1] = ^src[len(src)-i-1], ^src[i]
+		} else {
+			src[i], src[len(src)-i-1] = src[len(src)-i-1], src[i]
+		}
+	}
 }
 
 func (ck *CkService) FetchSchemerFromOtherNode(host, password string) error {


### PR DESCRIPTION
the bug phenomenon：
use query-execution page to query table and this table include decimal type column，but the ckman display ”Decimal128 is not supported “
solution：
I find clickhosue-go already fixed this bug，refer to ：ClickHouse/clickhouse-go#401
First I upgraded ckman‘s clickhouse-go dependence from v1.4.5 to v1.4.6
The ckman no longer display “Decimal128 is not supported”,but decimal type column became garbled，then I test clickhouse-server.go's QueryInfo function ,the problem was located.
when Clickhouse column is decimal type, it returns 16 length byte array ，so I fixed this bug refer to clickhouse-go V2 Code.