### PR TITLE
fix: remove quotes in case of tuple partition name

### DIFF
--- a/deploy/ck.go
+++ b/deploy/ck.go
@@ -116,14 +116,13 @@ func (d *CKDeploy) Init() error {
 					NeedSudo:         d.Conf.NeedSudo,
 					AuthenticateType: d.Conf.AuthenticateType,
 				}
-				cmd := "hostname -f"
-				output, err := common.RemoteExecute(sshOpts, cmd)
-				if err != nil {
-					lastError = err
-					return
-				}
+				cmd := "hostname"
+				output, _ := common.RemoteExecute(sshOpts, cmd)
 
 				hostname := strings.Trim(output, "\n")
+				if hostname == "" {
+					hostname = innerReplica.Ip
+				}
 				d.Conf.Shards[innerShardIndex].Replicas[innerReplicaIndex].HostName = hostname
 				lock.Lock()
 				HostNameMap[hostname] = true

--- a/service/clickhouse/clickhouse_service.go
+++ b/service/clickhouse/clickhouse_service.go
@@ -898,7 +898,7 @@ func GetReplicaZkPath(conf *model.CKManClickHouseConfig) error {
 	for _, database := range databases {
 		if tables, ok := dbtables[database]; ok {
 			for _, table := range tables {
-				path, err := getReplicaZkPath(service.DB, database, table)
+				path, err := GetZkPath(service.DB, database, table)
 				if err != nil {
 					return err
 				}
@@ -910,7 +910,7 @@ func GetReplicaZkPath(conf *model.CKManClickHouseConfig) error {
 	return nil
 }
 
-func getReplicaZkPath(db *sql.DB, database, table string) (string, error) {
+func GetZkPath(db *sql.DB, database, table string) (string, error) {
 	var err error
 	var path string
 	var rows *sql.Rows

--- a/service/zookeeper/zookeeper_service.go
+++ b/service/zookeeper/zookeeper_service.go
@@ -69,6 +69,9 @@ func GetZkService(clusterName string) (*ZkService, error) {
 }
 
 func (z *ZkService) GetReplicatedTableStatus(conf *model.CKManClickHouseConfig) ([]model.ZkReplicatedTableStatus, error) {
+	if !conf.IsReplica {
+		return nil, nil
+	}
 	err := clickhouse.GetReplicaZkPath(conf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The partition names may contain single quote in case it's a tuple with one of the member being a string. I faced this issue, and thought it might be helpful  in future.