### PR TITLE
feat: Delete the Zookeeper connection when the clickhouse cluster is …

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,9 @@ func main() {
 	}
 
 	zookeeper.ZkServiceCache = cache.New(time.Hour, time.Minute)
+	zookeeper.ZkServiceCache.OnEvicted(func(key string, value interface{}) {
+		value.(*zookeeper.ZkService).Conn.Close()
+	})
 
 	runnerServ := runner.NewRunnerService(selfIP, config.GlobalConfig.Server)
 	runnerServ.Start()

--- a/service/runner/ck.go
+++ b/service/runner/ck.go
@@ -57,7 +57,7 @@ func DestroyCkCluster(task *model.Task, d deploy.CKDeploy, conf *model.CKManClic
 
 	//clear zkNode
 	deploy.SetNodeStatus(task, model.NodeStatusClearData, model.ALL_NODES_DEFAULT)
-	service, err := zookeeper.NewZkService(conf.ZkNodes, conf.ZkPort)
+	service, err := zookeeper.GetZkService(conf.Cluster)
 	if err != nil {
 		return errors.Wrapf(err, "[%s]", model.NodeStatusClearData.EN)
 	}
@@ -74,6 +74,9 @@ func DestroyCkCluster(task *model.Task, d deploy.CKDeploy, conf *model.CKManClic
 			}
 		}
 	}
+
+	//clear zkConn
+	service.DeleteZkService(conf.Cluster)
 	return nil
 }
 

--- a/service/runner/ck.go
+++ b/service/runner/ck.go
@@ -58,6 +58,7 @@ func DestroyCkCluster(task *model.Task, d deploy.CKDeploy, conf *model.CKManClic
 	//clear zkNode
 	deploy.SetNodeStatus(task, model.NodeStatusClearData, model.ALL_NODES_DEFAULT)
 	service, err := zookeeper.GetZkService(conf.Cluster)
+	defer zookeeper.ZkServiceCache.Delete(conf.Cluster)
 	if err != nil {
 		return errors.Wrapf(err, "[%s]", model.NodeStatusClearData.EN)
 	}
@@ -74,9 +75,6 @@ func DestroyCkCluster(task *model.Task, d deploy.CKDeploy, conf *model.CKManClic
 			}
 		}
 	}
-
-	//clear zkConn
-	service.DeleteZkService(conf.Cluster)
 	return nil
 }
 
@@ -110,7 +108,7 @@ func DeleteCkClusterNode(task *model.Task, conf *model.CKManClickHouseConfig, ip
 	}
 
 	if conf.IsReplica {
-		service, err := zookeeper.NewZkService(conf.ZkNodes, conf.ZkPort)
+		service, err := zookeeper.GetZkService(conf.Cluster)
 		if err != nil {
 			return errors.Wrapf(err, "[%s]", model.NodeStatusClearData.EN)
 		}

--- a/service/zookeeper/zookeeper_service.go
+++ b/service/zookeeper/zookeeper_service.go
@@ -172,3 +172,8 @@ func (z *ZkService) DeletePathUntilNode(path, endNode string) error {
 		path = parent
 	}
 }
+
+func (z *ZkService) DeleteZkService(clusterName string) {
+	z.Conn.Close()
+	ZkServiceCache.Delete(clusterName)
+}

--- a/service/zookeeper/zookeeper_service.go
+++ b/service/zookeeper/zookeeper_service.go
@@ -172,8 +172,3 @@ func (z *ZkService) DeletePathUntilNode(path, endNode string) error {
 		path = parent
 	}
 }
-
-func (z *ZkService) DeleteZkService(clusterName string) {
-	z.Conn.Close()
-	ZkServiceCache.Delete(clusterName)
-}


### PR DESCRIPTION
1. 销毁CK集群时不用重新获取zookeeper的service，从缓存获取即可；
2.  销毁CK集群删除完zooPath后需要关闭zookeeper连接同时从Cache中删除，如果zk一直连着，那么就会每秒loop一次对应的IP，销毁集群时如果不清除zookeeper连接会导致日志出现大量的IO Error日志；
3. 添加zookeeper连接关闭和ZkServiceCache中删除对应记录的功能函数。